### PR TITLE
1456 - Make deploy script support comma seperated list of CF_NETWORKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ BOSH_URI=<https://10.0.0.6:25555> \
 CF_SYS_DOMAIN=<system.example.com> \
 CF_DEPLOY_USERNAME=<cf-username> \
 CF_DEPLOY_PASSWORD=<cf-password> \
-CF_NETWORK=<10.0.0.0/24> \
+CF_NETWORKS=<10.0.0.0/24,11.0.0.0/24> \
 ./deploy.sh
 ```
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -17,6 +17,12 @@ cf create-space etcd-leader-monitor
 echo "Targetting Space etcd-leader-monitor..."
 cf target -s etcd-leader-monitor
 echo "Setting up security groups..."
+if [ -z "${CF_NETWORKS}" ]; then
+# Disable this shellcheck warning as we know how to spell correctly.
+# shellcheck disable=SC2153
+CF_NETWORKS="${CF_NETWORK}"
+fi
+
 echo "[" > security_group.json
 last_subnet=$(echo "${CF_NETWORKS}" | awk -F, '{print $NF}')
 for subnet in ${CF_NETWORKS//,/ } ;


### PR DESCRIPTION
### What?

We need our security rules to be able to allow access from more than one single network range to cover occasions where we're being accessed from outside the NAT firewall. With this commit, we can now process a comma-separated list of CF_NETWORKS which are munged into the `security_group.json` file in the appropriate fashion.
### How to review?

Check the code changes.
Check the documentation changes.
Do the shellcheck checks (which of course I already did before raising this PR, but it's just good practice)
Deploy as before... N.B. The CF_NETWORK environment variable has been renamed to CF_NETWORKS, so some tweaking of the deploy pipeline will be required to cover this change.
### Who can review?

Anyone with write aceess to master branch on this repo.
